### PR TITLE
Escape newlines

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ export interface CreateLoggerOptions {
   metricsRegistry?: Registry;
   showDebug?: boolean;
   systemdPrefix?: boolean;
+  escapeNewlines?: boolean;
 }
 
 const systemd = Boolean(process.env.JOURNAL_STREAM);
@@ -21,9 +22,10 @@ export function create({
   metricsRegistry,
   showDebug,
   systemdPrefix = systemd,
+  escapeNewlines = systemd,
 }: CreateLoggerOptions = {}): LokeLogger {
   const streams: NodeJS.WritableStream[] = [
-    new ConsoleStream(undefined, undefined, systemdPrefix),
+    new ConsoleStream(undefined, undefined, systemdPrefix, escapeNewlines),
   ];
 
   if (syslog) {

--- a/lib/streams/console.test.ts
+++ b/lib/streams/console.test.ts
@@ -49,6 +49,10 @@ test("logger with debug true", (t) => {
   logger.error("error message");
   t.is(stderr.data[0], `${ERROR} error message\n`);
   stderr.clear();
+
+  logger.log("multiline\nmessage");
+  t.is(stdout.data[0], `${INFO} multiline\nmessage\n`);
+  stdout.clear();
 });
 
 test("logger with debug false", (t) => {
@@ -101,9 +105,9 @@ test("with prefix", (t) => {
   stdout.clear();
 });
 
-test("logger systemd prefix", (t) => {
+test("logger systemd prefix and newline escaping", (t) => {
   const logger = new LokeLogger({
-    streams: [new ConsoleStream(stdout.writable, stderr.writable, true)],
+    streams: [new ConsoleStream(stdout.writable, stderr.writable, true, true)],
   });
 
   logger.debug("debug message");
@@ -125,4 +129,8 @@ test("logger systemd prefix", (t) => {
   logger.error("error message");
   t.is(stderr.data[0], `<3>${ERROR} error message\n`);
   stderr.clear();
+
+  logger.log("multiline\nmessage");
+  t.is(stdout.data[0], `<6>${INFO} multiline\\nmessage\n`);
+  stdout.clear();
 });

--- a/lib/streams/console.ts
+++ b/lib/streams/console.ts
@@ -13,24 +13,32 @@ export class ConsoleStream extends Writable {
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
   systemdPrefix: boolean;
+  escapeNewlines: boolean;
 
   constructor(
     stdout: NodeJS.WritableStream = process.stdout,
     stderr: NodeJS.WritableStream = process.stderr,
     systemdPrefix = false,
+    escapeNewlines = false,
   ) {
     super({ objectMode: true });
     this.stdout = stdout;
     this.stderr = stderr;
     this.systemdPrefix = systemdPrefix;
+    this.escapeNewlines = escapeNewlines;
   }
 
   _write(log: Log, _: string, callback: () => void): void {
-    const { level, message } = log;
+    const { level } = log;
+    let message = log.message;
 
     let prefix = "";
     if (this.systemdPrefix) {
       prefix = SYSTEMD_PREFIX[level];
+    }
+
+    if (this.escapeNewlines) {
+      message = message.replace(/\n/g, "\\n");
     }
 
     switch (level) {


### PR DESCRIPTION
Adding newline escaping so each line represents one log event

This will work better for datadog, as well as preventing fake log injection attacks

Unfortunatly I haven't seen any way to get datadog to print a literal `\n`, so I haven't bothered escaping them. If this becomes an issue/someone finds a workaround we can re-address